### PR TITLE
Fix NextJS import error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.1.1] - 2024-07-14
 
-No changes in functionality, just fix NextJS import error by tweaking `package.json`
+No changes in functionality, just fix NextJS import error by tweaking `package.json`'s `.extends` property
 
 Fixes `Module not found: Default condition should be last one` (see [Issue #1](https://github.com/micahjon/rhf-conditional-logic/issues/1))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog / Releases
 
+## [0.1.1] - 2024-07-14
+
+No changes in functionality, just fix NextJS import error by tweaking `package.json`
+
+Fixes `Module not found: Default condition should be last one` (see [Issue #1](https://github.com/micahjon/rhf-conditional-logic/issues/1))
+
 ## [0.1.0] - 2023-12-29
 
 First stable release! No functionality changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [0.1.1] - 2024-07-14
 
-No changes in functionality, just fix NextJS import error by tweaking `package.json`'s `.extends` property
+_No changes in functionality._
 
-Fixes `Module not found: Default condition should be last one` (see [Issue #1](https://github.com/micahjon/rhf-conditional-logic/issues/1))
+- Fix NextJS import error ([`Module not found: Default condition should be last one`](https://github.com/micahjon/rhf-conditional-logic/issues/1)) by tweaking `package.json`'s "extends" property.
 
 ## [0.1.0] - 2023-12-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhf-conditional-logic",
-  "version": "0.0.3-alpha.1",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhf-conditional-logic",
-      "version": "0.0.3-alpha.1",
+      "version": "0.1.1",
       "dependencies": {
         "ts-extras": "^0.11.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhf-conditional-logic",
   "description": "Conditional Logic for React Hook Forms. Fully typed and compatible with resolvers (e.g. Zod)",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./dist/rhf-conditional-logic.cjs",
   "module": "./dist/rhf-conditional-logic.mjs",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/rhf-conditional-logic.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/micahjon/rhf-conditional-logic.git"
+    "url": "git+https://github.com/micahjon/rhf-conditional-logic.git"
   },
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,9 @@
   "module": "./dist/rhf-conditional-logic.mjs",
   "exports": {
     ".": {
-      "require": {
-        "default": "./dist/rhf-conditional-logic.cjs",
-        "types": "./dist/rhf-conditional-logic.d.ts"
-      },
-      "import": {
-        "default": "./dist/rhf-conditional-logic.mjs",
-        "types": "./dist/rhf-conditional-logic.d.ts"
-      }
+      "import": "./dist/rhf-conditional-logic.mjs",
+      "require": "./dist/rhf-conditional-logic.cjs",
+      "types": "./dist/rhf-conditional-logic.d.ts"
     }
   },
   "types": "./dist/rhf-conditional-logic.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "module": "./dist/rhf-conditional-logic.mjs",
   "exports": {
     ".": {
+      "types": "./dist/rhf-conditional-logic.d.ts",
       "import": "./dist/rhf-conditional-logic.mjs",
-      "require": "./dist/rhf-conditional-logic.cjs",
-      "types": "./dist/rhf-conditional-logic.d.ts"
+      "require": "./dist/rhf-conditional-logic.cjs"
     }
   },
   "types": "./dist/rhf-conditional-logic.d.ts",


### PR DESCRIPTION
Fixes https://github.com/micahjon/rhf-conditional-logic/issues/1

The `extends` property was out-of-order, so NextJS raised this error during import:
```Module not found: Default condition should be last one```